### PR TITLE
Add quote of the day feature

### DIFF
--- a/crates/goose-cli/src/commands/mod.rs
+++ b/crates/goose-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_version;
 pub mod configure;
 pub mod mcp;
+pub mod quote;
 pub mod session;
 pub mod version;

--- a/crates/goose-cli/src/commands/quote.rs
+++ b/crates/goose-cli/src/commands/quote.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use rand::seq::SliceRandom;
+
+pub fn get_quote_of_the_day() -> Result<()> {
+    let quotes = vec![
+        ("The only way to do great work is to love what you do.", "Steve Jobs"),
+        ("Be the change you wish to see in the world.", "Mahatma Gandhi"),
+        ("Stay hungry, stay foolish.", "Steve Jobs"),
+        ("Innovation distinguishes between a leader and a follower.", "Steve Jobs"),
+        ("The future belongs to those who believe in the beauty of their dreams.", "Eleanor Roosevelt"),
+    ];
+
+    let mut rng = rand::thread_rng();
+    if let Some(&(quote, author)) = quotes.choose(&mut rng) {
+        println!("\n🪿 Quote of the day:\n\n  \"{}\"\n  - {}\n", quote, author);
+    }
+
+    Ok(())
+}

--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -10,6 +10,7 @@ mod session;
 use commands::agent_version::AgentCommand;
 use commands::configure::handle_configure;
 use commands::mcp::run_server;
+use commands::quote::get_quote_of_the_day;
 use commands::session::build_session;
 use commands::version::print_version;
 use console::style;
@@ -35,6 +36,10 @@ enum Command {
     /// Configure Goose settings
     #[command(about = "Configure Goose settings")]
     Configure {},
+
+    /// Display a random quote of the day
+    #[command(about = "Display an inspirational quote of the day")]
+    Quote {},
 
     /// Manage system prompts and behaviors
     #[command(about = "Run one of the mcp servers bundled with goose")]
@@ -167,6 +172,10 @@ async fn main() -> Result<()> {
     match cli.command {
         Some(Command::Configure {}) => {
             let _ = handle_configure().await;
+            return Ok(());
+        }
+        Some(Command::Quote {}) => {
+            let _ = get_quote_of_the_day()?;
             return Ok(());
         }
         Some(Command::Mcp { name }) => {


### PR DESCRIPTION
This PR adds a new 'quote' command that displays an inspirational quote of the day.

Features:
- New  command
- Random selection from curated inspirational quotes
- Simple and clean display format with emoji

The quotes are currently hardcoded but could be expanded to use an external source in the future.

Testing:
- Basic syntax validation completed
- Command structure follows existing patterns
- No runtime dependencies beyond what's already in use

To test: run  to see a random inspirational quote.