### PR TITLE
fix: set default OLLAMA_HOST to include default port

### DIFF
--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 use std::time::Duration;
 use url::Url;
 
-pub const OLLAMA_HOST: &str = "localhost";
+pub const OLLAMA_HOST: &str = "localhost:11434";
 pub const OLLAMA_DEFAULT_PORT: u16 = 11434;
 pub const OLLAMA_DEFAULT_MODEL: &str = "qwen2.5";
 // Ollama can run many models, we only provide the default


### PR DESCRIPTION
Fixes #1

The default OLLAMA_HOST value now includes the default port (11434) to match ollama's default setup.

This ensures that when OLLAMA_HOST is not explicitly set, it will use localhost:11434 as the default value.