### PR TITLE
Set default OLLAMA_HOST value to localhost

### DIFF
--- a/crates/goose-server/src/routes/providers_and_keys.json
+++ b/crates/goose-server/src/routes/providers_and_keys.json
@@ -31,9 +31,12 @@
     },
     "ollama": {
         "name": "Ollama",
-        "description": "Lorem ipsum",
+        "description": "Local model runner supporting Qwen, Llama, DeepSeek, and other open-source models",
         "models": ["qwen2.5"],
-        "required_keys": ["OLLAMA_HOST"]
+        "required_keys": ["OLLAMA_HOST"],
+        "default_values": {
+            "OLLAMA_HOST": "localhost"
+        }
     },
     "openrouter": {
         "name": "OpenRouter",


### PR DESCRIPTION
Fixes #1 

Added default value for OLLAMA_HOST in the providers configuration to match the default value used by Ollama (localhost). This ensures the CLI/UI shows the correct default value instead of appearing blank.