### PR TITLE
Add Goose fix workflows for issues and PR comments

### DIFF
--- a/.github/workflows/goose-fix-issue.yml
+++ b/.github/workflows/goose-fix-issue.yml
@@ -1,0 +1,139 @@
+name: Goose Auto-Fix from Issue
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  goose-fix:
+    name: Run Goose to fix issue
+    # Only run when the "goose-fix" label is added
+    if: github.event.label.name == 'goose-fix'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for branch creation
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      
+      - name: Install Dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y libdbus-1-dev gnome-keyring libxcb1-dev just
+      
+      - name: Install Goose CLI
+        run: |
+          curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash -
+      
+      - name: Create Branch
+        run: |
+          # Create a branch name based on the issue number
+          BRANCH_NAME="goose-fix/issue-${{ github.event.issue.number }}"
+          git config user.name "Goose Bot"
+          git config user.email "goose-bot@users.noreply.github.com"
+          git checkout -b $BRANCH_NAME
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+      
+      - name: Run Goose to Fix Issue
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOSE_MODEL: gpt-4o
+          GOOSE_PROVIDER: openai
+        run: |
+          # Extract issue title and body for context
+          ISSUE_TITLE="${{ github.event.issue.title }}"
+          ISSUE_BODY="${{ github.event.issue.body }}"
+          
+          # Create a temporary context file with issue details
+          cat > /tmp/issue-context.txt <<EOF
+          Fix the following issue in this repository:
+          
+          Title: $ISSUE_TITLE
+          
+          Description:
+          $ISSUE_BODY
+          
+          Please analyze the issue, make the necessary changes to fix it, and explain what you did.
+          EOF
+          
+          # Run Goose with input file
+          goose run -i /tmp/issue-context.txt
+      
+      - name: Check for Changes
+        id: git-check
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Commit and Push Changes
+        if: steps.git-check.outputs.changes == 'true'
+        run: |
+          git add .
+          git commit -m "Fix issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
+          # Use PAT for push to ensure proper authentication
+          git remote set-url origin https://x-access-token:${{ secrets.GOOSE_PAT }}@github.com/${{ github.repository }}.git
+          git push origin $BRANCH_NAME
+      
+      - name: Create Pull Request
+        if: steps.git-check.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GOOSE_PAT }}
+          commit-message: "Fix issue #${{ github.event.issue.number }}"
+          branch: ${{ env.BRANCH_NAME }}
+          delete-branch: false
+          title: "Goose fix for issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
+          body: |
+            This PR was automatically created by Goose to fix issue #${{ github.event.issue.number }}.
+            
+            Original issue: ${{ github.event.issue.html_url }}
+            
+            ## Changes made:
+            
+            Goose analyzed the issue and made the following changes to address it.
+            
+            Please review these changes to ensure they correctly fix the issue.
+          labels: automated-pr, needs-review
+      
+      - name: Comment on Issue
+        if: steps.git-check.outputs.changes == 'true'
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            I've created a fix for this issue! 🤖
+            
+            The changes are available in PR #${{ steps.create-pr.outputs.pull-request-number }}
+      
+      - name: Comment on Issue (No Changes)
+        if: steps.git-check.outputs.changes == 'false'
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            I tried to fix this issue, but didn't make any changes to the codebase.
+            
+            This might be because:
+            1. The issue description wasn't clear enough
+            2. The issue requires more complex changes than I can handle automatically
+            3. The issue might be invalid or already fixed
+            
+            Please provide more details or assign this to a human developer.

--- a/.github/workflows/goose-fix-pr-comment.yml
+++ b/.github/workflows/goose-fix-pr-comment.yml
@@ -1,0 +1,163 @@
+name: Goose Auto-Fix from PR Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check-comment:
+    name: Check for "goose-fix" comment
+    runs-on: ubuntu-latest
+    # Only run on PR comments, not issue comments
+    if: github.event.issue.pull_request
+    outputs:
+      should-fix: ${{ steps.check-comment.outputs.should-fix }}
+      pr-number: ${{ github.event.issue.number }}
+    
+    steps:
+      - name: Check if comment contains "goose-fix"
+        id: check-comment
+        run: |
+          COMMENT="${{ github.event.comment.body }}"
+          # Match "goose-fix" as a standalone word or command (with punctuation)
+          if [[ $COMMENT =~ (^|[[:space:]])goose-fix([[:space:]]|$|[[:punct:]]) ]]; then
+            echo "should-fix=true" >> $GITHUB_OUTPUT
+          else
+            echo "should-fix=false" >> $GITHUB_OUTPUT
+          fi
+
+  goose-fix:
+    name: Run Goose to fix PR issues
+    needs: check-comment
+    if: needs.check-comment.outputs.should-fix == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+      - name: Get PR details
+        id: pr-details
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr_number = ${{ needs.check-comment.outputs.pr-number }};
+            
+            const pr = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pr_number
+            });
+            
+            return {
+              branch: pr.data.head.ref,
+              repo: pr.data.head.repo.full_name,
+              sha: pr.data.head.sha
+            }
+      
+      - name: Checkout PR Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ fromJson(steps.pr-details.outputs.result).branch }}
+          repository: ${{ fromJson(steps.pr-details.outputs.result).repo }}
+          fetch-depth: 0
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      
+      - name: Install Dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y libdbus-1-dev gnome-keyring libxcb1-dev just
+      
+      - name: Install Goose CLI
+        run: |
+          curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash -
+      
+      - name: Get Check Runs
+        id: check-runs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = "${{ fromJson(steps.pr-details.outputs.result).sha }}";
+            
+            const checkRuns = await github.rest.checks.listForRef({
+              owner,
+              repo,
+              ref: sha
+            });
+            
+            const failedChecks = checkRuns.data.check_runs.filter(check => 
+              check.conclusion === 'failure' || check.conclusion === 'timed_out'
+            );
+            
+            const failedCheckNames = failedChecks.map(check => check.name);
+            
+            return {
+              hasFailures: failedChecks.length > 0,
+              failedChecks: failedCheckNames
+            }
+      
+      - name: Run Goose to Fix PR Issues
+        if: fromJson(steps.check-runs.outputs.result).hasFailures
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOSE_MODEL: gpt-4o
+          GOOSE_PROVIDER: openai
+        run: |
+          # Extract failed checks
+          FAILED_CHECKS='${{ toJson(fromJson(steps.check-runs.outputs.result).failedChecks) }}'
+          
+          # Create a temporary context file with PR check information
+          cat > /tmp/pr-context.txt <<EOF
+          This PR has failed CI checks: $FAILED_CHECKS
+          
+          Please analyze the failing checks, examine the code in this branch, and make the necessary changes to fix the failing checks.
+          Focus on addressing code style issues, linting errors, test failures, or build errors that might be causing these checks to fail.
+          
+          After analyzing the issues, implement fixes and explain what changes you made.
+          EOF
+          
+          # Run Goose with input file
+          goose run -i /tmp/pr-context.txt
+      
+      - name: Check for Changes
+        id: git-check
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Commit and Push Changes
+        if: steps.git-check.outputs.changes == 'true'
+        run: |
+          git config user.name "Goose Bot"
+          git config user.email "goose-bot@users.noreply.github.com"
+          git add .
+          git commit -m "Fix CI issues for PR #${{ needs.check-comment.outputs.pr-number }}"
+          # Use PAT for push to ensure proper authentication
+          git remote set-url origin https://x-access-token:${{ secrets.GOOSE_PAT }}@github.com/${{ github.repository }}.git
+          git push
+      
+      - name: Comment on PR
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ needs.check-comment.outputs.pr-number }}
+          body: |
+            I've analyzed the failing checks and made changes to fix the issues! 🤖
+            
+            ${{ steps.git-check.outputs.changes == 'true' && 'The changes have been pushed to this branch. Please check if the CI checks pass now.' || 'I analyzed the issues but didn\'t make any changes. This might require human intervention.' }}
+            
+            Failed checks I attempted to fix:
+            ${{ toJson(fromJson(steps.check-runs.outputs.result).failedChecks) }}


### PR DESCRIPTION
This PR adds two GitHub Actions workflows:

1. A workflow that triggers when an issue is labeled with 'goose-fix' and uses Goose to fix the issue
2. A workflow that triggers when a PR comment contains 'goose-fix' and uses Goose to fix failing CI checks

These workflows need to be in the main branch to be triggered by GitHub events.