### PR TITLE
Fix branch handling in goose-fix workflow

### DIFF
--- a/.github/workflows/goose-fix-issue.yml
+++ b/.github/workflows/goose-fix-issue.yml
@@ -46,6 +46,14 @@ jobs:
           BRANCH_NAME="goose-fix/issue-${{ github.event.issue.number }}"
           git config user.name "Goose Bot"
           git config user.email "goose-bot@users.noreply.github.com"
+          
+          # Check if branch exists remotely and delete it if it does
+          if git ls-remote --heads origin $BRANCH_NAME | grep -q $BRANCH_NAME; then
+            echo "Branch $BRANCH_NAME exists remotely, deleting it"
+            git push origin --delete $BRANCH_NAME || true
+          fi
+          
+          # Create new branch
           git checkout -b $BRANCH_NAME
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
       
@@ -111,7 +119,7 @@ jobs:
           git commit -m "Fix issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
           # Use PAT for push to ensure proper authentication
           git remote set-url origin https://x-access-token:${{ secrets.GOOSE_PAT }}@github.com/${{ github.repository }}.git
-          git push origin $BRANCH_NAME
+          git push -f origin $BRANCH_NAME
       
       - name: Create Pull Request
         if: steps.git-check.outputs.changes == 'true'


### PR DESCRIPTION
This PR fixes the branch handling in the goose-fix workflow to:

1. Delete the branch if it already exists before creating it
2. Use force push to ensure the branch can be updated even if there are conflicts

These changes will make the workflow more reliable when triggered multiple times for the same issue.