### PR TITLE
Use built-in GITHUB_TOKEN instead of PAT

### DIFF
--- a/.github/workflows/goose-fix-issue.yml
+++ b/.github/workflows/goose-fix-issue.yml
@@ -110,15 +110,14 @@ jobs:
         run: |
           git add .
           git commit -m "Fix issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
-          # Use PAT for push to ensure proper authentication
-          git remote set-url origin https://x-access-token:${{ secrets.GOOSE_PAT }}@github.com/${{ github.repository }}.git
+          # Use built-in GITHUB_TOKEN for authentication
           git push origin $BRANCH_NAME
       
       - name: Create Pull Request
         if: steps.git-check.outputs.changes == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GOOSE_PAT }}
+          token: ${{ github.token }}
           commit-message: "Fix issue #${{ github.event.issue.number }}"
           base: main
           branch: ${{ env.BRANCH_NAME }}
@@ -140,6 +139,7 @@ jobs:
         if: steps.git-check.outputs.changes == 'true'
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ github.token }}
           issue-number: ${{ github.event.issue.number }}
           body: |
             I've created a fix for this issue! 🤖
@@ -150,6 +150,7 @@ jobs:
         if: steps.git-check.outputs.changes == 'false'
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ github.token }}
           issue-number: ${{ github.event.issue.number }}
           body: |
             I tried to fix this issue, but didn't make any changes to the codebase.

--- a/.github/workflows/goose-fix-issue.yml
+++ b/.github/workflows/goose-fix-issue.yml
@@ -120,6 +120,7 @@ jobs:
         with:
           token: ${{ secrets.GOOSE_PAT }}
           commit-message: "Fix issue #${{ github.event.issue.number }}"
+          base: main
           branch: ${{ env.BRANCH_NAME }}
           delete-branch: false
           title: "Goose fix for issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}"

--- a/.github/workflows/goose-fix-pr-comment.yml
+++ b/.github/workflows/goose-fix-pr-comment.yml
@@ -146,13 +146,13 @@ jobs:
           git config user.email "goose-bot@users.noreply.github.com"
           git add .
           git commit -m "Fix CI issues for PR #${{ needs.check-comment.outputs.pr-number }}"
-          # Use PAT for push to ensure proper authentication
-          git remote set-url origin https://x-access-token:${{ secrets.GOOSE_PAT }}@github.com/${{ github.repository }}.git
+          # Use built-in GITHUB_TOKEN for authentication
           git push
       
       - name: Comment on PR
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ github.token }}
           issue-number: ${{ needs.check-comment.outputs.pr-number }}
           body: |
             I've analyzed the failing checks and made changes to fix the issues! 🤖


### PR DESCRIPTION
This PR updates the goose-fix workflows to use the built-in GITHUB_TOKEN instead of a custom PAT.

Changes:
1. Removed the need for the GOOSE_PAT secret
2. Updated all actions to use the built-in token
3. Simplified the git push commands

This makes the workflow easier to set up and maintain as it no longer requires a separate PAT to be configured.