### PR TITLE
Fix label handling in PR creation

### DIFF
--- a/.github/workflows/goose-fix-issue.yml
+++ b/.github/workflows/goose-fix-issue.yml
@@ -117,6 +117,11 @@ jobs:
         id: create-pr
         if: steps.git-check.outputs.changes == 'true'
         run: |
+          # Create labels if they don't exist
+          gh label list --repo ${{ github.repository }} | grep -q "automated-pr" || gh label create automated-pr -c "#0E8A16" -d "Pull request created automatically by a workflow" --repo ${{ github.repository }}
+          gh label list --repo ${{ github.repository }} | grep -q "needs-review" || gh label create needs-review -c "#FBCA04" -d "Pull request needs review" --repo ${{ github.repository }}
+          
+          # Create the PR
           PR_URL=$(gh pr create --title "Goose fix for issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}" \
             --body "This PR was automatically created by Goose to fix issue #${{ github.event.issue.number }}.
             
@@ -127,7 +132,7 @@ jobs:
             Goose analyzed the issue and made the following changes to address it.
             
             Please review these changes to ensure they correctly fix the issue." \
-            --label "automated-pr,needs-review" \
+            --label "automated-pr" --label "needs-review" \
             --base main \
             --head ${{ env.BRANCH_NAME }})
           echo "PR created: $PR_URL"


### PR DESCRIPTION
This PR fixes an issue with the goose-fix workflow where it was failing to create a PR because the labels didn't exist. This PR:

1. Adds code to check if labels exist and create them if they don't
2. Uses separate --label flags for each label instead of a comma-separated list

This should resolve the issue where the workflow was failing when trying to create a PR.