### PR TITLE
Fix PR number parsing in PR comment workflow

### DIFF
--- a/.github/workflows/goose-fix-pr-comment.yml
+++ b/.github/workflows/goose-fix-pr-comment.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
-            const pr_number = ${{ needs.check-comment.outputs.pr-number }};
+            const pr_number = parseInt("${{ needs.check-comment.outputs.pr-number }}");
             
             const pr = await github.rest.pulls.get({
               owner,


### PR DESCRIPTION
This PR fixes an issue with the goose-fix-pr-comment workflow where it was failing to start due to improper parsing of the PR number. The fix wraps the PR number in quotes and uses parseInt to properly convert it to a number.