### PR TITLE
Fix PR comment workflow based on working issue workflow

### DIFF
--- a/.github/workflows/goose-fix-pr-comment.yml
+++ b/.github/workflows/goose-fix-pr-comment.yml
@@ -6,17 +6,17 @@ on:
 
 jobs:
   goose-fix:
-    name: Run Goose to fix PR
+    name: Run Goose to fix PR from comment
     # Only run on PR comments that contain "goose-fix"
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'goose-fix') }}
+    if: github.event.issue.pull_request && contains(github.event.comment.body, 'goose-fix')
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     
     steps:
-      - name: Get PR branch
-        id: get-pr
+      - name: Get PR details
+        id: pr-details
         uses: actions/github-script@v7
         with:
           script: |
@@ -37,8 +37,8 @@ jobs:
       - name: Checkout PR Branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ fromJson(steps.get-pr.outputs.result).branch }}
-          repository: ${{ fromJson(steps.get-pr.outputs.result).repo }}
+          ref: ${{ fromJson(steps.pr-details.outputs.result).branch }}
+          repository: ${{ fromJson(steps.pr-details.outputs.result).repo }}
           fetch-depth: 0
           token: ${{ github.token }}
       
@@ -67,20 +67,29 @@ jobs:
           GOOSE_MODEL: gpt-4o
           GOOSE_PROVIDER: openai
         run: |
-          # Get the comment that triggered the workflow
-          COMMENT="${{ github.event.comment.body }}"
+          # Extract the comment that triggered the workflow
+          COMMENT_BODY="${{ github.event.comment.body }}"
           
           # Create a temporary context file with the comment
           cat > /tmp/pr-context.txt <<EOF
-          Please make the changes requested in this comment:
+          Please make the changes requested in this PR comment:
           
-          ${COMMENT}
+          ${COMMENT_BODY}
           
           Analyze the request, make the necessary changes, and explain what you did.
           EOF
           
+          # Debug: Check if goose is installed and working
+          echo "Goose version:"
+          goose --version
+          
           # Run Goose with input file
+          echo "Running Goose with input file"
           goose run -i /tmp/pr-context.txt
+          
+          # Debug: Show git status
+          echo "Git status after running Goose:"
+          git status
       
       - name: Check for Changes
         id: git-check
@@ -109,4 +118,4 @@ jobs:
           body: |
             I've made the requested changes! 🤖
             
-            ${{ steps.git-check.outputs.changes == 'true' && 'The changes have been pushed to this branch.' || 'I analyzed the request but didn''t make any changes. This might require human intervention.' }}
+            ${{ steps.git-check.outputs.changes == 'true' && 'The changes have been pushed to this branch.' || 'I analyzed the request but did not make any changes. This might require human intervention.' }}

--- a/.github/workflows/pr-comment-handler.yml
+++ b/.github/workflows/pr-comment-handler.yml
@@ -1,0 +1,107 @@
+name: PR Comment Handler
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  handle-pr-comment:
+    name: Handle PR Comment
+    # Only run on PR comments that contain "goose-fix"
+    if: github.event.issue.pull_request && contains(github.event.comment.body, 'goose-fix')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+      - name: Get PR branch
+        id: get-pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            
+            const { data: pull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: issue_number
+            });
+            
+            return {
+              branch: pull.head.ref,
+              repo: pull.head.repo.full_name
+            }
+      
+      - name: Checkout PR Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ fromJson(steps.get-pr.outputs.result).branch }}
+          repository: ${{ fromJson(steps.get-pr.outputs.result).repo }}
+          fetch-depth: 0
+          token: ${{ github.token }}
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      
+      - name: Install Dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y libdbus-1-dev gnome-keyring libxcb1-dev just
+      
+      - name: Install Goose CLI
+        run: |
+          curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash -
+      
+      - name: Process Comment
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOSE_MODEL: gpt-4o
+          GOOSE_PROVIDER: openai
+        run: |
+          # Extract the comment
+          COMMENT_BODY="${{ github.event.comment.body }}"
+          
+          # Create input file for Goose
+          echo "Processing comment: $COMMENT_BODY"
+          echo "Please make the changes requested in this comment: $COMMENT_BODY" > /tmp/input.txt
+          echo "Analyze the request, make the necessary changes, and explain what you did." >> /tmp/input.txt
+          
+          # Run Goose
+          goose run -i /tmp/input.txt
+      
+      - name: Check for Changes
+        id: git-check
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Commit and Push Changes
+        if: steps.git-check.outputs.changes == 'true'
+        run: |
+          git config user.name "Goose Bot"
+          git config user.email "goose-bot@users.noreply.github.com"
+          git add .
+          git commit -m "Apply changes requested in PR comment"
+          git push
+      
+      - name: Add Comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          token: ${{ github.token }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            I've processed your request! 🤖
+            
+            ${{ steps.git-check.outputs.changes == 'true' && 'Changes have been pushed to this branch.' || 'I analyzed the request but did not make any changes.' }}


### PR DESCRIPTION
This PR creates a new PR comment workflow directly based on the working issue workflow. 

The workflow:
1. Triggers on PR comments containing 'goose-fix'
2. Gets PR details and checks out the PR branch
3. Runs Goose on the comment content
4. Commits and pushes changes to the same PR branch
5. Comments on the PR with the results

I've carefully followed the structure of the working issue workflow to ensure this one works correctly.